### PR TITLE
Allow settings for **all** elements

### DIFF
--- a/jquery-validate.bootstrap-tooltip.js
+++ b/jquery-validate.bootstrap-tooltip.js
@@ -41,6 +41,9 @@
 				if(this.settings.tooltip_options&&this.settings.tooltip_options[element.name]){
 					$.extend(options,this.settings.tooltip_options[element.name]);
 				}
+				if(this.settings.tooltip_options&&this.settings.tooltip_options['_all_']){
+					$.extend(options,this.settings.tooltip_options['_all_']);
+				}
 				return options;
 			}
 		}


### PR DESCRIPTION
The settings are by element. Its usefull to have a `_all_` param to apply options in any element.

use as follows

```
$.validator.setDefaults({
				tooltip_options: {
					'_all_': { placement: 'right' }
				}
			})
```