### PR TITLE
Update jquery-validate.bootstrap-tooltip.js

### DIFF
--- a/jquery-validate.bootstrap-tooltip.js
+++ b/jquery-validate.bootstrap-tooltip.js
@@ -19,10 +19,19 @@
 					}
 				});
 				$.each( this.errorList, function(index, value) {
-					$(value.element).removeClass(self.settings.validClass).addClass(self.settings.errorClass).tooltip('destroy').tooltip(self.apply_tooltip_options(value.element,value.message)).tooltip('show'); 			
-					if ( self.settings.highlight ) {
-						self.settings.highlight.call( self, value.element, self.settings.errorClass, self.settings.validClass );
-					}
+					    var currentElement = $(value.element);
+			                    if (currentElement.data('bs.tooltip') != undefined) {
+			                        currentElement.data('bs.tooltip').options.title = value.message;
+			                    }
+			                    else {
+			                        currentElement.tooltip(self.apply_tooltip_options(value.element, value.message));
+			                    }
+			
+			                    $(value.element).removeClass(self.settings.validClass).addClass(self.settings.errorClass).tooltip('show');
+			
+			                    if (self.settings.highlight) {
+			                        self.settings.highlight.call(self, value.element, self.settings.errorClass, self.settings.validClass);
+			                    }
 				});
 			},
 			


### PR DESCRIPTION
When the blur event happens on a control the tooltip flickers or sometimes dissapears, the problem its the line  'tooltip("destroy")' because when you destroy followed by tooltip create doesnt work, with this commit the tooltip message is changed without destroying it, solving the problem 